### PR TITLE
chore(python): update python library

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "int64-buffer": "^0.1.10",
     "nintendo-switch-eshop": "^1.1.3",
     "node-fetch": "^2.2.0",
-    "python-shell": "^0.5.0",
+    "python-shell": "^1.0.2",
     "unzipper": "^0.9.3",
     "winston": "2.4.4",
     "xml2js": "^0.4.19"
@@ -53,7 +53,6 @@
     "@types/hapi": "^17.0.18",
     "@types/node": "^10.9.2",
     "@types/node-fetch": "^2.1.2",
-    "@types/python-shell": "^0.4.1",
     "@types/unzipper": "^0.9.0",
     "@types/winston": "^2.4.4",
     "@types/xml2js": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "commit": "git-cz",
     "lint": "tslint --project tsconfig.json --fix src/**/*.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prebuild": "rimraf dist",
+    "prebuild": "rimraf dist && rm node_modules/python-shell/index.ts",
     "build": "tsc",
     "postbuild": "cpx 'src/**/*.py' dist",
     "dev": "nodemon src/index.ts -- --root=./tmp --level=debug",

--- a/src/files/parser/py/decrypt.ts
+++ b/src/files/parser/py/decrypt.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import { run } from "python-shell";
+import { PythonShell } from "python-shell";
 
 export interface DecryptOptions {
   key: string;
@@ -14,10 +14,11 @@ export function decrypt({
 }: DecryptOptions): Promise<string[]> {
   return new Promise((res, reject) => {
     const args = ["--key", key, "--file", resolve(inputPath), "--out", output];
-    run(
+    PythonShell.run(
       "decryptxts.py",
-      { args, scriptPath: __dirname },
-      (err, results: string[]) => (err ? reject(err) : res(results))
+      { args, scriptPath: __dirname, pythonPath: "python" },
+      (err, results: string[] | undefined) =>
+        err ? reject(err) : res(results || [])
     );
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "typeRoots": ["node_modules/@types", "./src/types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "tsfl"]
+  "exclude": ["node_modules"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -23,8 +23,5 @@
     "interface-name": false
   },
   "excludes": ["node_modules", "./src/polyfills"],
-  "cliOptions": {
-    "exclude": ["tsfl"]
-  },
   "rulesDirectory": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,12 +121,6 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/podium/-/podium-1.0.0.tgz#bfaa2151be2b1d6109cc69f7faa9dac2cba3bb20"
 
-"@types/python-shell@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@types/python-shell/-/python-shell-0.4.1.tgz#5eac2cf408e31ed8f870b30eeab1128d11a932ed"
-  dependencies:
-    "@types/events" "*"
-
 "@types/shot@*":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@types/shot/-/shot-3.4.0.tgz#459477c5187d3ebd303660ab099e7e9e0f3b656f"
@@ -2988,9 +2982,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-python-shell@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/python-shell/-/python-shell-0.5.0.tgz#461983bafd092010bc2760c365b13e7d50aab231"
+python-shell@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/python-shell/-/python-shell-1.0.2.tgz#6770cb3f748682f5154f6354b4661e9b4bfa29b8"
 
 q@^1.5.0:
   version "1.5.1"


### PR DESCRIPTION
Need to manually specify the pythion executable now because python-shell wants to use python3 by
default, and the script is not compatible

closes #6